### PR TITLE
feat: dont show users in leaderboard if no progress done

### DIFF
--- a/src/main/java/com/stgsporting/piehmecup/repositories/UserRepository.java
+++ b/src/main/java/com/stgsporting/piehmecup/repositories/UserRepository.java
@@ -28,7 +28,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM User u LEFT JOIN u.positions WHERE u.id = :id")
     Optional<User> findUserByIdWithPositions(Long id);
 
-    @Query("SELECT u FROM User u WHERE u.schoolYear = :schoolYear AND u.leaderboardBoolean = true ORDER BY u.lineupRating.lineupRating desc")
+    @Query("SELECT u FROM User u WHERE u.schoolYear = :schoolYear AND u.leaderboardBoolean = true " +
+            "AND u.lineupRating.lineupRating > 4.55 ORDER BY u.lineupRating.lineupRating desc")
     List<User> findUsersBySchoolYear(SchoolYear schoolYear);
 
     @Query("SELECT u FROM User u WHERE u.schoolYear = :schoolYear and u.username LIKE :search ORDER BY u.lineupRating.lineupRating desc, u.id asc")

--- a/src/main/java/com/stgsporting/piehmecup/repositories/UserRepository.java
+++ b/src/main/java/com/stgsporting/piehmecup/repositories/UserRepository.java
@@ -29,7 +29,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findUserByIdWithPositions(Long id);
 
     @Query("SELECT u FROM User u WHERE u.schoolYear = :schoolYear AND u.leaderboardBoolean = true " +
-            "AND u.lineupRating.lineupRating > 4.55 ORDER BY u.lineupRating.lineupRating desc")
+            "AND u.lineupRating.lineupRating > 4.55 ORDER BY u.lineupRating.lineupRating desc, u.id asc")
     List<User> findUsersBySchoolYear(SchoolYear schoolYear);
 
     @Query("SELECT u FROM User u WHERE u.schoolYear = :schoolYear and u.username LIKE :search ORDER BY u.lineupRating.lineupRating desc, u.id asc")


### PR DESCRIPTION
## Filter Leaderboard

- User default lineup rating is 4.545454 which is (50/11) 
- This commit filters these users that didn't have progress from the lineup to reduce the overhead of fetching unsubscribed users

### Why this approach works
- If the user purchased a player the lineup rating will be >= 12 which is (86+50) / 11
- If the user upgraded his card the lineup rating will be >= 4.56 which is (50+1) / 11
so in both scenarios the user will be shown in the leaderboard on making progress