### PR TITLE
Bug: User Rating miscalculation when user position is CM/CB

### DIFF
--- a/src/main/java/com/stgsporting/piehmecup/exceptions/PositionOccupiedException.java
+++ b/src/main/java/com/stgsporting/piehmecup/exceptions/PositionOccupiedException.java
@@ -1,0 +1,7 @@
+package com.stgsporting.piehmecup.exceptions;
+
+public class PositionOccupiedException extends RuntimeException {
+    public PositionOccupiedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/stgsporting/piehmecup/exceptions/RestResponseEntityExceptionResolver.java
+++ b/src/main/java/com/stgsporting/piehmecup/exceptions/RestResponseEntityExceptionResolver.java
@@ -55,6 +55,11 @@ public class RestResponseEntityExceptionResolver extends ResponseEntityException
         return handleExceptionDefault(ex, HttpStatus.BAD_REQUEST, request);
     }
 
+    @ExceptionHandler(value = { PositionOccupiedException.class })
+    protected ResponseEntity<Object> handlePositionOccupied(PositionOccupiedException ex, WebRequest request) {
+        return handleExceptionDefault(ex, HttpStatus.BAD_REQUEST, request);
+    }
+
     @ExceptionHandler(value = { InvalidCredentialsException.class })
     protected ResponseEntity<Object> handleInvalidCred(InvalidCredentialsException ex, WebRequest request) {
         return handleExceptionDefault(ex, HttpStatus.BAD_REQUEST, request);

--- a/src/main/java/com/stgsporting/piehmecup/services/SelectPositionService.java
+++ b/src/main/java/com/stgsporting/piehmecup/services/SelectPositionService.java
@@ -1,15 +1,15 @@
 package com.stgsporting.piehmecup.services;
 
 import com.stgsporting.piehmecup.dtos.PositionDTO;
+import com.stgsporting.piehmecup.entities.Player;
 import com.stgsporting.piehmecup.entities.Position;
 import com.stgsporting.piehmecup.entities.User;
-import com.stgsporting.piehmecup.exceptions.PositionNotFoundException;
-import com.stgsporting.piehmecup.exceptions.UnownedPositionException;
-import com.stgsporting.piehmecup.exceptions.UserNotFoundException;
+import com.stgsporting.piehmecup.exceptions.*;
 import com.stgsporting.piehmecup.repositories.PositionRepository;
 import com.stgsporting.piehmecup.repositories.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class SelectPositionService {
@@ -29,6 +29,24 @@ public class SelectPositionService {
 
         if (!user.getPositions().contains(position)) {
             throw new UnownedPositionException();
+        }
+
+        if (position.getName().equals("CM") || position.getName().equals("CB")) {
+            for (Player player : user.getPlayers()) {
+                if (player.getPosition().equals(position)) {
+                    throw new PositionOccupiedException("Position already occupied by player " + player.getName());
+                }
+            }
+        } else {
+            int count = 0;
+            for(Player player : user.getPlayers()) {
+                if(player.getPosition().equals(position)) {
+                    count++;
+                }
+            }
+            if(count >= 2) {
+                throw new PositionOccupiedException("Position already occupied by 2 players");
+            }
         }
 
         user.setSelectedPosition(position);

--- a/src/main/java/com/stgsporting/piehmecup/services/SelectPositionService.java
+++ b/src/main/java/com/stgsporting/piehmecup/services/SelectPositionService.java
@@ -9,7 +9,6 @@ import com.stgsporting.piehmecup.repositories.PositionRepository;
 import com.stgsporting.piehmecup.repositories.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class SelectPositionService {

--- a/user_rating_view.sql
+++ b/user_rating_view.sql
@@ -10,7 +10,6 @@ FROM
     LEFT JOIN owned_players ON users.id = owned_players.user_id
     LEFT JOIN players ON players.id = owned_players.player_id
 WHERE
-    players.position_id != users.position_id
-    OR players.position_id IS NULL
+    players.position_id IS NULL
 GROUP BY
     users.id;


### PR DESCRIPTION
# Problem Description
- CM/CB positions differs from other positions that they are found twice in the lineup
- When the user chooses his position as CM/CB, the rating is calculated without the other CM/CB 

### Debugging Approach and Solution
- This approach restrict the user from selecting a position that already occupied by a player.
- Also it removes the condition `players.position_id != users.position_id` as it is obsolete by the previous restriction

### What to do next
- Check if there are players that already selected CM/CB positions and have more than one player in that position